### PR TITLE
Add SQL quasi-quoter, fix test suite

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,8 +1,14 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Main where
+
+import Gogurl.Sqlite (Connection, FromRow, Only(Only), Query, sql)
+
+import qualified Gogurl.Sqlite as Sqlite
+  (close, execute, executeFile, lastInsertRowId, open, query)
 
 import Control.Monad (join)
 import Control.Monad.IO.Class (liftIO)
@@ -18,15 +24,6 @@ import Data.Aeson
 import Data.Int (Int64)
 import Data.Pool
 import Data.Text (Text)
-import qualified Data.Text.IO as T (readFile)
-import Database.SQLite.Simple
-  ( Connection
-  , FromRow(..)
-  , Only(Only, fromOnly)
-  , Query(Query)
-  , ToRow
-  )
-import qualified Database.SQLite.Simple as Sqlite
 import Options.Applicative
 import Web.Scotty
 
@@ -77,8 +74,7 @@ main' port database = do
   let withConn :: (Connection -> IO r) -> IO r
       withConn = withResource pool
   -- Create tables if they don't exist.
-  createTables <- T.readFile "db/links.sql"
-  withConn (\conn -> Sqlite.execute conn (Query createTables) ())
+  withConn (\conn -> Sqlite.executeFile conn "db/links.sql")
   -- Run the web server.
   scotty port (app withConn)
 
@@ -86,14 +82,14 @@ app :: (forall r. (Connection -> IO r) -> IO r) -> ScottyM ()
 app withConn
   -- Partially apply Sqlite functions to the given database runner, so the
   -- handlers become more readable.
-      -- Execute a SQL statement.
  = do
-  let statement :: ToRow v => Query -> v -> ActionM ()
-      statement q v = liftIO (withConn (\conn -> Sqlite.execute conn q v))
+      -- Execute a SQL statement.
+  let statement :: Query -> ActionM ()
+      statement q = liftIO (withConn (\conn -> Sqlite.execute conn q))
 
       -- Execute a SQL query.
-  let query :: (FromRow r, ToRow v) => Query -> v -> ActionM [r]
-      query q v = liftIO (withConn (\conn -> Sqlite.query conn q v))
+  let query :: FromRow r => Query -> ActionM [r]
+      query q = liftIO (withConn (\conn -> Sqlite.query conn q))
 
       -- Get the rowid of the last successful INSERT statement.
   let lastInsertRowId :: ActionM Int64
@@ -102,33 +98,44 @@ app withConn
   -- Here are the actual handlers.
   get "/" $ do
     topUrls :: [(Text, Text)] <-
-      query "SELECT name, url FROM Link ORDER BY hits DESC" ()
+      query [sql| SELECT name, url
+                  FROM link
+                  ORDER BY hits
+                  DESC |]
     json topUrls
 
   get "/links" $ redirect "https://go/"
 
   post "/links" $ do
     Link name url <- jsonData
-    statement "INSERT INTO link (name, url) VALUES (?, ?)" (name, url)
+    statement [sql| INSERT INTO link (name, url)
+                    VALUES (:name, :url) |]
     newID <- lastInsertRowId
     json $ object ["result" .= String "success", "id" .= newID]
 
   get "/links/:name/delete" $ do
-    name <- param "name"
-    statement "DELETE FROM link WHERE name = ?" (Only (name :: Text))
+    name :: Text <- param "name"
+    statement [sql| DELETE FROM link
+                    WHERE name = :name |]
     json $ object ["result" .= String "success", "name" .= name]
 
   get "/links/:name/edit/:url" $ do
     name :: Text <- param "name"
     url :: Text <- param "url"
-    statement "UPDATE link SET url = ? WHERE name = ?" (url, name)
+    statement [sql| UPDATE link
+                    SET url = :url
+                    WHERE name = :name |]
     json $ object ["result" .= String "success", "id" .= name]
 
   get "/:name" $ do
     name :: Text <- param "name"
-    urls <- query "SELECT url FROM link WHERE name = ?" (Only name)
+    urls <- query [sql| SELECT url
+                        FROM link
+                        WHERE name = :name |]
     case urls of
       [] -> errorJson 2 "No record found"
       Only url:_ -> do
-        statement "UPDATE link SET hits = hits + 1 WHERE name = ?" (Only name)
+        statement [sql| UPDATE link
+                        SET hits = hits + 1
+                        WHERE name = :name |]
         redirect url

--- a/gogurl.cabal
+++ b/gogurl.cabal
@@ -13,16 +13,27 @@ build-type:          Simple
 extra-source-files:  README.md
 cabal-version:       >=1.10
 
+library
+  hs-source-dirs:      src
+  default-language:    Haskell2010
+  ghc-options:         -Wall
+  build-depends:       base
+                     , sqlite-simple
+                     , template-haskell
+                     , text
+  exposed-modules:     Gogurl.Sqlite
+
 executable gogurl
   hs-source-dirs:      app
   main-is:             Main.hs
   default-language:    Haskell2010
+  ghc-options:         -Wall
   build-depends:       base >= 4.7 && < 5
                      , aeson
+                     , gogurl
                      , optparse-applicative
                      , resource-pool
                      , scotty
-                     , sqlite-simple
                      , text
 
 test-suite gogurl-app-tests
@@ -30,6 +41,7 @@ test-suite gogurl-app-tests
   type:                exitcode-stdio-1.0
   main-is:             Main.hs
   default-language:    Haskell2010
+  ghc-options:         -Wall
   build-depends:       base >= 4.7 && < 5
                      , HUnit
                      , managed

--- a/src/Gogurl/Sqlite.hs
+++ b/src/Gogurl/Sqlite.hs
@@ -1,0 +1,104 @@
+{-# language LambdaCase #-}
+{-# language TemplateHaskell #-}
+
+-- | This module is intented to replace @sqlite-simple@. It provides a
+-- quasi-quoter with variable interpolation as a lightweight alternative to
+-- the "named" query support provided by @sqlite-simple@.
+
+module Gogurl.Sqlite
+  ( Query
+  , sql
+  , execute
+  , executeFile
+  , query
+    -- * Re-exports
+  , module X
+  ) where
+
+import Control.Monad.Fail (MonadFail)
+import Data.Char (isAlphaNum, isLower, isSpace)
+import Data.Text (pack)
+import Database.SQLite.Simple (Connection, FromRow, NamedParam)
+import Language.Haskell.TH
+import Language.Haskell.TH.Quote
+import Language.Haskell.TH.Syntax (lift)
+
+import qualified Data.Text.IO as Text
+import qualified Database.SQLite.Simple as Sqlite
+
+import Database.SQLite.Simple as X
+  (Connection, FromRow, Only(Only), close, lastInsertRowId, open)
+
+data Query
+  = Query [Char] [NamedParam]
+
+execute :: Connection -> Query -> IO ()
+execute conn (Query q params) =
+  Sqlite.executeNamed conn (Sqlite.Query (pack q)) params
+
+executeFile :: Connection -> FilePath -> IO ()
+executeFile conn path = do
+  bytes <- Text.readFile path
+  Sqlite.execute_ conn (Sqlite.Query bytes)
+
+query :: FromRow r => Connection -> Query -> IO [r]
+query conn (Query q params) =
+  Sqlite.queryNamed conn (Sqlite.Query (pack q)) params
+
+sql :: QuasiQuoter
+sql =
+  QuasiQuoter
+    { quoteExp = \s -> do
+        let s' = unwords (map (dropWhile isSpace) (lines s))
+        names <- parseParams s'
+        conE 'Query `appE` lift s' `appE` listE (map namedParam names)
+
+    , quoteDec = error "sql: quoteDec not defined"
+    , quotePat = error "sql: quotePat not defined"
+    , quoteType = error "sql: quoteType not defined"
+    }
+
+-- | Pluck out the params prefixed by ':' from a string.
+--
+-- >>> parseParams "foo :bar baz :qux"
+-- [["bar", "qux"]]
+parseParams :: MonadFail m => [Char] -> m [[Char]]
+parseParams = \case
+  [] ->
+    pure []
+  ':':x:xs
+    | isIdent1 x ->
+        let
+          (ys, zs) =
+            span isIdent xs
+        in
+          ((x:ys):) <$> parseParams zs
+    | otherwise ->
+        fail ("Invalid identifier: " ++ x:xs)
+  _:xs ->
+    parseParams (dropWhile (/= ':') xs)
+ where
+  isIdent1 :: Char -> Bool
+  isIdent1 x =
+    isLower x || x == '_'
+
+  isIdent :: Char -> Bool
+  isIdent x =
+    isAlphaNum x || x == '_' || x == '\''
+
+-- | Make a Template Haskell expression of a NamedParam.
+--
+-- For example,
+--
+--   namedParam "foo"
+--
+-- would result in the following expression:
+--
+--   ":foo" := foo
+namedParam :: [Char] -> Q Exp
+namedParam s =
+  lookupValueName s >>= \case
+    Nothing ->
+        fail ("Variable " ++ s ++ " not in scope")
+    Just name ->
+      conE '(Sqlite.:=) `appE` lift (':' : s) `appE` varE name

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -20,7 +20,7 @@ main = runManaged $ do
 
   (@?= "Location: bar\r\n")
     =<< bash "curl -i -s localhost:16789/foo | grep Location"
-  (@?= "[\"bar\"]")
+  (@?= "[[\"foo\",\"bar\"]]")
     =<< bash "curl -s localhost:16789/"
 
   -- Update: foo -> qux
@@ -28,7 +28,7 @@ main = runManaged $ do
 
   (@?= "Location: qux\r\n")
     =<< bash "curl -i -s localhost:16789/foo | grep Location"
-  (@?= "[\"qux\"]")
+  (@?= "[[\"foo\",\"qux\"]]")
     =<< bash "curl -s localhost:16789/"
 
   -- Delete: foo -> qux


### PR DESCRIPTION
This patch adds a SQL quasi-quoter for better inline SQL syntax. Now, instead of passing all of the variables after the SQL string, like before...

```haskell
execute "INSERT INTO foo (what, ever) VALUES (?, ?)" (yo, hi)
```

... the values prefixed with a `:` are just looked up at compile time:

```haskell
execute [sql| INSERT INTO foo (what, ever)
              VALUES (:yo, :hi) |]
```